### PR TITLE
If QUDA CG is enabled, then WANT_EIG_GPU must be also be enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -473,6 +473,10 @@ ifeq ($(strip ${WANTQUDA}),true)
   WANT_GAUGEFIX_OVR_GPU ?= #true
   WANT_MULTIGRID ?= #true
 
+  # If QUDA CG is enabled, then eigensolve/deflation must be enabled
+  ifeq ($(strip ${WANT_FN_CG_GPU}),true)
+    WANT_EIG_GPU = true
+  endif
 endif
 
 ifeq ($(strip ${WANTQUDA}),true)


### PR DESCRIPTION
QUDA CG now supports deflation (via eigensolve or loading eigenvectors from file). So if QUDA CG is enabled, USE_EIG_GPU must be defined to give access to the eigen_params struct.